### PR TITLE
fix(terraform): clean up script path and interpolation syntax ł fix(template):  use -cpu host for better compatibility

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,13 +57,13 @@ network {
   
   # Déclaration du script de démarrage, en utilisant user it-anthony + clé SSH privée
   provisioner "file" {
-    source      = "~/Documents/Terraform/startup.sh"
+    source      = "startup.sh"
     destination = "/tmp/startup.sh"
       connection {
       type     = "ssh"
       user     = "it-anthony"
-      private_key     = "${file("~/.ssh/id_rsa")}"
-      host     = "${self.ssh_host}"
+      private_key     = file("~/.ssh/id_rsa")
+      host     = self.ssh_host
    }
   }
   # Exécution du script de démarrage
@@ -75,8 +75,8 @@ network {
     connection {
       type     = "ssh"
       user     = "it-anthony"
-      private_key     = "${file("~/.ssh/id_rsa")}"
-      host     = "${self.ssh_host}"
+      private_key     = file("~/.ssh/id_rsa")
+      host     = self.ssh_host
    }
   }
 }

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,8 @@
 sleep 30 && sudo apt-get update && sleep 10 && sudo apt-get upgrade -y && sleep 30 && sudo apt-get dist-upgrade -y && sleep 30
 
 # Installation dépendances pour Docker
-sudo apt -y install software-properties-common apt-transport-https ca-certificates curl gnupg2 software-properties-common && sleep 30
+# Installation dépendances pour Docker
+sudo apt -y install software-properties-common apt-transport-https ca-certificates curl gnupg2 && sleep 30
 
 # Ajout du dépôt Docker et de la clé 
 curl -fsSL https://download.docker.com/linux/debian/gpg | sudo apt-key add -

--- a/startup.sh
+++ b/startup.sh
@@ -8,7 +8,6 @@
 sleep 30 && sudo apt-get update && sleep 10 && sudo apt-get upgrade -y && sleep 30 && sudo apt-get dist-upgrade -y && sleep 30
 
 # Installation dépendances pour Docker
-# Installation dépendances pour Docker
 sudo apt -y install software-properties-common apt-transport-https ca-certificates curl gnupg2 && sleep 30
 
 # Ajout du dépôt Docker et de la clé 

--- a/template-debian-1000.sh
+++ b/template-debian-1000.sh
@@ -4,7 +4,7 @@
 # Mis à jour le 20-05-20
 
 # Création d'une VM avec ID 1000 nommée debian-10-template, 2Go RAM, 1 proco, 2 coeurs
-qm create 1000 -name debian-10-template -memory 2048 -net0 virtio,bridge=vmbr0 -cores 2 -sockets 1 -cpu cputype=kvm64 -kvm 1 -numa 1
+qm create 1000 -name debian-10-template -memory 2048 -net0 virtio,bridge=vmbr0 -cores 2 -sockets 1 -cpu host -kvm 1 -numa 1
 # Import du disque
 qm importdisk 1000 debian-10-openstack-amd64.qcow2 local-lvm
 # Attachement du disque à la VM


### PR DESCRIPTION
This pull request includes the following improvements : 
- startup.sh : 
Removed duplicate declaration of software-properties-common in the Docker dependencies installation line.
- main.tf : 
Replaced deprecated Terraform interpolation syntax (e.g., ${file(...)} ➝ file(...)).
Changed the startup script path from an absolute (~/Documents/Terraform/startup.sh) to a relative one (startup.sh) for better portability.
- template-debian-1000.sh : 
Replaced -cpu cputype=kvm64 with -cpu host for improved CPU compatibility with the host machine.